### PR TITLE
Remove norm methods from matrix classes. To compute the norm of a ten…

### DIFF
--- a/src/main/java/org/flag4j/core/MatrixComparisonsMixin.java
+++ b/src/main/java/org/flag4j/core/MatrixComparisonsMixin.java
@@ -41,12 +41,4 @@ public interface MatrixComparisonsMixin<T> {
      * @return True if this matrix is the identity matrix. Otherwise, returns false.
      */
     boolean isI();
-
-
-    /**
-     * Checks if matrices are inverses of each other.
-     * @param B Second matrix.
-     * @return True if matrix B is an inverse of this matrix. Otherwise, returns false. Otherwise, returns false.
-     */
-    boolean isInv(T B);
 }

--- a/src/main/java/org/flag4j/core/MatrixOperationsMixin.java
+++ b/src/main/java/org/flag4j/core/MatrixOperationsMixin.java
@@ -30,7 +30,6 @@ import org.flag4j.dense.CMatrix;
 import org.flag4j.dense.CVector;
 import org.flag4j.dense.Matrix;
 import org.flag4j.dense.Vector;
-import org.flag4j.linalg.decompositions.svd.SVD;
 import org.flag4j.sparse.CooCMatrix;
 import org.flag4j.sparse.CooCVector;
 import org.flag4j.sparse.CooMatrix;
@@ -1057,15 +1056,6 @@ public interface MatrixOperationsMixin<
      */
     X tr();
 
-
-    /**
-     * Computes the condition number of this matrix using {@link SVD SVD}.
-     * Specifically, the condition number is computed as the maximum singular value divided by the minimum singular
-     * value of this matrix.
-     *
-     * @return The condition number of this matrix (Assuming Frobenius norm).
-     */
-    double cond();
 
     /**
      * Extracts the diagonal elements of this matrix and returns them as a vector.

--- a/src/main/java/org/flag4j/core/MatrixPropertiesMixin.java
+++ b/src/main/java/org/flag4j/core/MatrixPropertiesMixin.java
@@ -119,22 +119,6 @@ public interface MatrixPropertiesMixin {
 
 
     /**
-     * Computes the L<sub>p, q</sub> norm of this matrix.
-     * @param p P value in the L<sub>p, q</sub> norm.
-     * @param q Q value in the L<sub>p, q</sub> norm.
-     * @return The L<sub>p, q</sub> norm of this matrix.
-     */
-    double norm(double p, double q);
-
-
-    /**
-     * Computes the max norm of a matrix.
-     * @return The max norm of this matrix.
-     */
-    double maxNorm();
-
-
-    /**
      * Computes the rank of this matrix (i.e. the dimension of the column space of this matrix).
      * Note that here, rank is <b>NOT</b> the same as a tensor rank.
      *

--- a/src/main/java/org/flag4j/core/TensorPropertiesMixin.java
+++ b/src/main/java/org/flag4j/core/TensorPropertiesMixin.java
@@ -75,28 +75,4 @@ interface TensorPropertiesMixin {
      * entry (in row-major ordering) are returned.
      */
     int[] argMax();
-
-
-    /**
-     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(double) norm(2)}.
-     * @return the 2-norm of this tensor.
-     */
-    double norm();
-
-
-    /**
-     * Computes the p-norm of this tensor.
-     * @param p The p value in the p-norm. <br>
-     *          - If p is inf, then this method computes the maximum/infinite norm.
-     * @return The p-norm of this tensor.
-     * @throws IllegalArgumentException If p is less than 1.
-     */
-    double norm(double p);
-
-
-    /**
-     * Computes the maximum/infinite norm of this tensor.
-     * @return The maximum/infinite norm of this tensor.
-     */
-    double infNorm();
 }

--- a/src/main/java/org/flag4j/core/dense_base/RealDenseTensorBase.java
+++ b/src/main/java/org/flag4j/core/dense_base/RealDenseTensorBase.java
@@ -137,12 +137,6 @@ public abstract class RealDenseTensorBase<T extends RealDenseTensorBase<T, W>, W
 
 
     @Override
-    public double infNorm() {
-        return AggregateReal.maxAbs(entries);
-    }
-
-
-    @Override
     public boolean isPos() {
         return RealProperties.isPos(entries);
     }

--- a/src/main/java/org/flag4j/core/sparse_base/ComplexSparseTensorBase.java
+++ b/src/main/java/org/flag4j/core/sparse_base/ComplexSparseTensorBase.java
@@ -169,12 +169,6 @@ public abstract class ComplexSparseTensorBase<T, U, Y>
 
 
     @Override
-    public double infNorm() {
-        return AggregateComplex.maxAbs(entries);
-    }
-
-
-    @Override
     public boolean isZeros() {
         return ComplexProperties.isZeros(entries);
     }

--- a/src/main/java/org/flag4j/core/sparse_base/RealSparseTensorBase.java
+++ b/src/main/java/org/flag4j/core/sparse_base/RealSparseTensorBase.java
@@ -183,12 +183,6 @@ public abstract class RealSparseTensorBase<
 
 
     @Override
-    public double infNorm() {
-    return AggregateReal.maxAbs(entries);
-    }
-
-
-    @Override
     public boolean isPos() {
     return RealProperties.isPos(entries);
     }

--- a/src/main/java/org/flag4j/dense/CVector.java
+++ b/src/main/java/org/flag4j/dense/CVector.java
@@ -30,7 +30,7 @@ import org.flag4j.core.VectorMixin;
 import org.flag4j.core.dense_base.ComplexDenseTensorBase;
 import org.flag4j.core.dense_base.DenseVectorMixin;
 import org.flag4j.io.PrintOptions;
-import org.flag4j.operations.common.real.VectorNorms;
+import org.flag4j.linalg.VectorNorms;
 import org.flag4j.operations.dense.complex.ComplexDenseVectorOperations;
 import org.flag4j.operations.dense.real_complex.RealComplexDenseElemDiv;
 import org.flag4j.operations.dense.real_complex.RealComplexDenseElemMult;
@@ -362,42 +362,6 @@ public class CVector extends ComplexDenseTensorBase<CVector, Vector>
     protected Vector makeRealTensor(Shape shape, double[] entries) {
         // Shape not needed to make vector.
         return new Vector(entries);
-    }
-
-
-    /**
-     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(double) norm(2)}.
-     *
-     * @return the 2-norm of this tensor.
-     */
-    @Override
-    public double norm() {
-        return VectorNorms.norm(entries);
-    }
-
-
-    /**
-     * Computes the p-norm of this tensor. Warning, if p is large in absolute value, overflow errors may occur.
-     *
-     * @param p The p value in the p-norm. <br>
-     *          - If p is {@link Double#POSITIVE_INFINITY}, then this method computes the maximum/infinite norm.<br>
-     *          - If p is {@link Double#NEGATIVE_INFINITY}, then this method computes the minimum norm.
-     * @return The p-norm of this tensor.
-     */
-    @Override
-    public double norm(double p) {
-        return VectorNorms.norm(entries, p);
-    }
-
-
-    /**
-     * Computes the maximum/infinite norm of this tensor.
-     *
-     * @return The maximum/infinite norm of this tensor.
-     */
-    @Override
-    public double infNorm() {
-        return maxAbs();
     }
 
 
@@ -891,7 +855,7 @@ public class CVector extends ComplexDenseTensorBase<CVector, Vector>
      */
     @Override
     public CVector normalize() {
-        double norm = this.norm();
+        double norm = VectorNorms.norm(this);
         return norm==0 ? new CVector(size) : this.div(norm);
     }
 

--- a/src/main/java/org/flag4j/dense/Vector.java
+++ b/src/main/java/org/flag4j/dense/Vector.java
@@ -30,7 +30,7 @@ import org.flag4j.core.VectorMixin;
 import org.flag4j.core.dense_base.DenseVectorMixin;
 import org.flag4j.core.dense_base.RealDenseTensorBase;
 import org.flag4j.io.PrintOptions;
-import org.flag4j.operations.common.real.VectorNorms;
+import org.flag4j.linalg.VectorNorms;
 import org.flag4j.operations.dense.real.RealDenseEquals;
 import org.flag4j.operations.dense.real.RealDenseVectorOperations;
 import org.flag4j.operations.dense.real_complex.RealComplexDenseElemDiv;
@@ -810,7 +810,7 @@ public class Vector
      */
     @Override
     public Vector normalize() {
-        double norm = this.norm();
+        double norm = VectorNorms.norm(this);
         return norm==0 ? new Vector(size) : this.div(norm);
     }
 
@@ -1034,31 +1034,6 @@ public class Vector
      */
     public Tensor toTensor() {
         return new Tensor(this.shape.copy(), this.entries.clone());
-    }
-
-
-    /**
-     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(double) norm(2)}.
-     *
-     * @return the 2-norm of this tensor.
-     */
-    @Override
-    public double norm() {
-        return VectorNorms.norm(entries);
-    }
-
-
-    /**
-     * Computes the p-norm of this tensor. Warning, if p is large in absolute value, overflow errors may occur.
-     *
-     * @param p The p value in the p-norm. <br>
-     *          - If p is {@link Double#POSITIVE_INFINITY}, then this method computes the maximum/infinite norm.
-     *          - If p is {@link Double#NEGATIVE_INFINITY}, then this method computes the minimum norm.
-     * @return The p-norm of this tensor.
-     */
-    @Override
-    public double norm(double p) {
-        return VectorNorms.norm(entries, p);
     }
 
 

--- a/src/main/java/org/flag4j/linalg/Condition.java
+++ b/src/main/java/org/flag4j/linalg/Condition.java
@@ -1,0 +1,128 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024. Jacob Watters
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.flag4j.linalg;
+
+import org.flag4j.dense.CMatrix;
+import org.flag4j.dense.Matrix;
+import org.flag4j.dense.Vector;
+import org.flag4j.linalg.decompositions.svd.ComplexSVD;
+import org.flag4j.linalg.decompositions.svd.RealSVD;
+import org.flag4j.util.ErrorMessages;
+
+
+/**
+ * Utility class for computing the condition number of a matrix.
+ */
+public class Condition {
+
+    private Condition() {
+        // Hide default constructor for utility class
+        throw new IllegalStateException(ErrorMessages.getUtilityClassErrMsg());
+    }
+
+
+    /**
+     * Computes the condition number of this matrix using the 2-norm.
+     * Specifically, the condition number is computed as the norm of this matrix multiplied by the norm
+     * of the inverse of this matrix.
+     *
+     * @param src Matrix to compute the condition number of.
+     * @return The condition number of this matrix (Assuming 2-norm). This value may be
+     * {@link Double#POSITIVE_INFINITY infinite}.
+     */
+    public static double cond(Matrix src) {
+        return cond(src, 2);
+    }
+
+
+    /**
+     * Computes the condition number of this matrix using a specified norm. The condition number of a matrix is defined
+     * as the norm of a matrix multiplied by the norm of the inverse of the matrix.
+     * @param src Matrix to compute the condition number of.
+     * @param p Specifies the order of the norm to be used when computing the condition number.
+     *          Common {@code p} values include:<br>
+     *          - {@code p} = {@link Double#POSITIVE_INFINITY}, {@link MatrixNorms#infNorm(Matrix)}.<br>
+     *          - {@code p} = 2, The standard matrix 2-norm (the largest singular value).<br>
+     *          - {@code p} = -2, The Smallest singular value.<br>
+     *          - {@code p} = 1, Maximum absolute row sum.<br>
+     * @return The condition number of this matrix using the specified norm. This value may be
+     * {@link Double#POSITIVE_INFINITY infinite}.
+     */
+    public static double cond(Matrix src, double p) {
+        double cond;
+
+        if(p==2 || p==-2) {
+            // Compute the singular value decomposition of the matrix.
+            Vector s = new RealSVD(false).decompose(src).getS().getDiag();
+            cond = p==2 ? s.max()/s.min() : s.min()/s.max();
+        } else {
+            cond = MatrixNorms.norm(src, p)*MatrixNorms.norm(Invert.inv(src), p);
+        }
+
+        return cond;
+    }
+
+
+    /**
+     * Computes the condition number of this matrix using the 2-norm.
+     * Specifically, the condition number is computed as the norm of this matrix multiplied by the norm
+     * of the inverse of this matrix.
+     *
+     * @param src Matrix to compute the condition number of.
+     * @return The condition number of this matrix (Assuming 2-norm). This value may be
+     * {@link Double#POSITIVE_INFINITY infinite}.
+     */
+    public static double cond(CMatrix src) {
+        return cond(src,2);
+    }
+
+
+    /**
+     * Computes the condition number of this matrix using a specified norm. The condition number of a matrix is defined
+     * as the norm of a matrix multiplied by the norm of the inverse of the matrix.
+     * @param src Matrix to compute the condition number of.
+     * @param p Specifies the order of the norm to be used when computing the condition number.
+     *          Common {@code p} values include:<br>
+     *          - {@code p} = {@link Double#POSITIVE_INFINITY}, {@link MatrixNorms#infNorm(CMatrix)}.<br>
+     *          - {@code p} = 2, The standard matrix 2-norm (the largest singular value).<br>
+     *          - {@code p} = -2, The Smallest singular value.<br>
+     *          - {@code p} = 1, Maximum absolute row sum.<br>
+     * @return The condition number of this matrix using the specified norm. This value may be
+     * {@link Double#POSITIVE_INFINITY infinite}.
+     */
+    public static double cond(CMatrix src, double p) {
+        double cond;
+
+        if(p==2 || p==-2) {
+            // Compute the singular value decomposition of the matrix.
+            Vector s = new ComplexSVD(false).decompose(src).getS().getDiag();
+            cond = p==2 ? s.max()/s.min() : s.min()/s.max();
+        } else {
+            cond = MatrixNorms.norm(src, p) * MatrixNorms.norm(Invert.inv(src), p);
+        }
+
+        return cond;
+    }
+}

--- a/src/main/java/org/flag4j/linalg/Invert.java
+++ b/src/main/java/org/flag4j/linalg/Invert.java
@@ -291,10 +291,52 @@ public class Invert {
      *
      * @return The Moore–Penrose pseudo-inverse of this matrix.
      */
-    public CMatrix pInv(CMatrix src) {
+    public static CMatrix pInv(CMatrix src) {
         SVD<CMatrix> svd = new ComplexSVD().decompose(src);
         Matrix sInv = Invert.invDiag(svd.getS());
 
         return svd.getV().mult(sInv).mult(svd.getU().H());
+    }
+
+    // -------------------------------------------------------------------
+
+    /**
+     * Checks if matrices are inverses of each other. This method rounds values near zero to zero when checking
+     * if the two matrices are inverses to account for floating point precision loss.
+     *
+     * @param src1 First matrix.
+     * @param src2 Second matrix.
+     * @return True if matrix src2 is an inverse of this matrix. Otherwise, returns false. Otherwise, returns false.
+     */
+    public static boolean isInv(Matrix src1, Matrix src2) {
+        boolean result;
+
+        if(!src1.isSquare() || !src2.isSquare() || !src1.shape.equals(src2.shape)) {
+            result = false;
+        } else {
+            result = src1.mult(src2).isCloseToI();
+        }
+
+        return result;
+    }
+
+
+    /**
+     * Checks if matrices are inverses of each other.
+     *
+     * @param src1 First matrix.
+     * @param src2 Second matrix.
+     * @return True if matrix src2 is an inverse (approximately) of this matrix. Otherwise, returns false. Otherwise, returns false.
+     */
+    public static boolean isInv(CMatrix src1, CMatrix src2) {
+        boolean result;
+
+        if(!src1.isSquare() || !src2.isSquare() || !src1.shape.equals(src2.shape)) {
+            result = false;
+        } else {
+            result = src1.mult(src2).isCloseToI();
+        }
+
+        return result;
     }
 }

--- a/src/main/java/org/flag4j/linalg/MatrixNorms.java
+++ b/src/main/java/org/flag4j/linalg/MatrixNorms.java
@@ -1,0 +1,358 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024. Jacob Watters
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.flag4j.linalg;
+
+
+import org.flag4j.dense.CMatrix;
+import org.flag4j.dense.Matrix;
+import org.flag4j.operations.dense.complex.ComplexDenseOperations;
+import org.flag4j.operations.dense.real.RealDenseOperations;
+import org.flag4j.operations.sparse.coo.complex.ComplexSparseNorms;
+import org.flag4j.operations.sparse.coo.real.RealSparseNorms;
+import org.flag4j.operations.sparse.csr.real.RealCsrOperations;
+import org.flag4j.sparse.CooCMatrix;
+import org.flag4j.sparse.CooMatrix;
+import org.flag4j.sparse.CsrMatrix;
+import org.flag4j.util.ErrorMessages;
+
+/**
+ * Utility class for computing norms of matrices.
+ */
+public class MatrixNorms {
+
+    private MatrixNorms() {
+        // Hide default constructor for utility class
+        throw new IllegalStateException(ErrorMessages.getUtilityClassErrMsg());
+    }
+
+
+    /**
+     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(Matrix, double) norm(2)}.
+     * This will be equal to the largest singular value of the matrix.
+     *
+     * @param src Matrix to compute norm of.
+     *
+     * @return the 2-norm of this tensor.
+     */
+    public static double norm(Matrix src) {
+        return RealDenseOperations.tensorNormL2(src.entries);
+    }
+
+
+    /**
+     * Computes the p-norm of this tensor. Equivalent to calling {@link #norm(Matrix, double, double) norm(p, p)}
+     *
+     * @param src Matrix to compute norm of.
+     * @param p The p value in the p-norm. <br>
+     *          - If p is inf, then this method computes the maximum/infinite norm.
+     * @return The p-norm of this tensor.
+     * @throws IllegalArgumentException If p is less than 1.
+     */
+    public static double norm(Matrix src, double p) {
+        double norm;
+
+        if(Double.isInfinite(p)) {
+            if(p > 0) {
+                norm = maxNorm(src);
+            } else {
+                norm = src.minAbs();
+            }
+        } else {
+            norm = RealDenseOperations.tensorNormLp(src.entries, p);
+        }
+
+        return norm;
+    }
+
+
+    /**
+     * Computes the maximum norm of this matrix. That is, the maximum value in the matrix.
+     *
+     * @param src Matrix to compute norm of.
+     * @return The maximum norm of this matrix.
+     * @see #infNorm(Matrix)
+     */
+    public static double maxNorm(Matrix src) {
+        return RealDenseOperations.matrixMaxNorm(src.entries);
+    }
+
+
+    /**
+     * Computes the infinite norm of this matrix. that is the maximum row sum in the matrix.
+     *
+     * @param src Matrix to compute norm of.
+     * @return The infinite norm of this matrix.
+     * @see #maxNorm(Matrix)
+     */
+    public static double infNorm(Matrix src) {
+        return RealDenseOperations.matrixInfNorm(src.entries, src.shape);
+    }
+
+
+    /**
+     * Computes the L<sub>p, q</sub> norm of this matrix.
+     *
+     * @param p P value in the L<sub>p, q</sub> norm.
+     * @param q Q value in the L<sub>p, q</sub> norm.
+     * @return The L<sub>p, q</sub> norm of this matrix.
+     */
+    public static double norm(Matrix src, double p, double q) {
+        return RealDenseOperations.matrixNormLpq(src.entries, src.shape, p, q);
+    }
+
+
+    /**
+     * Computes the L<sub>p, q</sub> norm of this matrix.
+     *
+     * @param src Matrix to compute norm of.
+     * @param p P value in the L<sub>p, q</sub> norm.
+     * @param q Q value in the L<sub>p, q</sub> norm.
+     * @return The L<sub>p, q</sub> norm of this matrix.
+     */
+    public static double norm(CMatrix src, double p, double q) {
+        return ComplexDenseOperations.matrixNormLpq(src.entries, src.shape, p, q);
+    }
+
+
+    /**
+     * Computes the max norm of a matrix.
+     *
+     * @param src Matrix to compute norm of.
+     * @return The max norm of this matrix.
+     */
+    public static double maxNorm(CMatrix src) {
+        return ComplexDenseOperations.matrixMaxNorm(src.entries);
+    }
+
+
+    /**
+     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(CMatrix, double) norm(2)}.
+     *
+     * @param src Matrix to compute norm of.
+     * @return the 2-norm of this tensor.
+     */
+    public static double norm(CMatrix src) {
+        return ComplexDenseOperations.matrixNormL2(src.entries, src.shape);
+    }
+
+
+    /**
+     * Computes the p-norm of this tensor.
+     *
+     * @param src Matrix to compute norm of.
+     * @param p The p value in the p-norm. <br>
+     *          - If p is inf, then this method computes the maximum/infinite norm.
+     * @return The p-norm of this tensor.
+     * @throws IllegalArgumentException If p is less than 1.
+     */
+    public static double norm(CMatrix src, double p) {
+        double norm;
+
+        if(Double.isInfinite(p)) {
+            if(p > 0) {
+                norm = maxNorm(src);
+            } else {
+                norm = src.minAbs();
+            }
+        } else {
+            norm = ComplexDenseOperations.matrixNormLp(src.entries, src.shape, p);
+        }
+
+        return norm;
+    }
+
+
+    /**
+     * Computes the maximum/infinite norm of this tensor.
+     *
+     * @param src Matrix to compute norm of.
+     * @return The maximum/infinite norm of this tensor.
+     */
+    public static double infNorm(CMatrix src) {
+        return ComplexDenseOperations.matrixInfNorm(src.entries, src.shape);
+    }
+
+
+    // ------------------------------ Sparse COO Matrices ------------------------------
+    /**
+     * Computes the L<sub>p, q</sub> norm of this matrix.
+     *
+     * @param src Matrix to compute norm of.
+     * @param p P value in the L<sub>p, q</sub> norm.
+     * @param q Q value in the L<sub>p, q</sub> norm.
+     * @return The L<sub>p, q</sub> norm of this matrix.
+     */
+    public static double norm(CooMatrix src, double p, double q) {
+        // Sparse implementation is usually only faster for very sparse matrices.
+        return src.sparsity()>=0.95 ? RealSparseNorms.matrixNormLpq(src, p, q) :
+                norm(src.toDense(), p, q);
+    }
+
+
+    /**
+     * Computes the max norm of a matrix.
+     *
+     * @param src Matrix to compute norm of.
+     * @return The max norm of this matrix.
+     */
+    public static double maxNorm(CooMatrix src) {
+        return RealDenseOperations.matrixMaxNorm(src.entries);
+    }
+
+
+    /**
+     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(CooMatrix, double) norm(2)}.
+     *
+     * @param src Matrix to compute norm of.
+     * @return the 2-norm of this tensor.
+     */
+    public static double norm(CooMatrix src) {
+        // Sparse implementation is usually only faster for very sparse matrices.
+        return src.sparsity()>=0.95 ? RealSparseNorms.matrixNormL2(src) :
+                norm(src.toDense());
+    }
+
+
+    /**
+     * Computes the p-norm of this tensor.
+     *
+     * @param src Matrix to compute norm of.
+     * @param p The p value in the p-norm. <br>
+     *          - If p is inf, then this method computes the maximum/infinite norm.
+     * @return The p-norm of this tensor.
+     * @throws IllegalArgumentException If p is less than 1.
+     */
+    public static double norm(CooMatrix src, double p) {
+        // Sparse implementation is usually only faster for very sparse matrices.
+        return src.sparsity()>=0.95 ? RealSparseNorms.matrixNormLp(src, p) :
+                norm(src.toDense(), p);
+    }
+
+
+    /**
+     * Computes the L<sub>p, q</sub> norm of this matrix.
+     *
+     * @param src Matrix to compute norm of.
+     * @param p P value in the L<sub>p, q</sub> norm.
+     * @param q Q value in the L<sub>p, q</sub> norm.
+     * @return The L<sub>p, q</sub> norm of this matrix.
+     */
+    public static double norm(CooCMatrix src, double p, double q) {
+        // Sparse implementation is usually only faster for very sparse matrices.
+        return src.sparsity()>=0.95 ? ComplexSparseNorms.matrixNormLpq(src, p, q) :
+                norm(src.toDense(), p, q);
+    }
+
+
+    /**
+     * Computes the max norm of a matrix.
+     *
+     * @param src Matrix to compute norm of.
+     * @return The max norm of this matrix.
+     */
+    public static double maxNorm(CooCMatrix src) {
+        return ComplexDenseOperations.matrixMaxNorm(src.entries);
+    }
+
+
+    /**
+     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(CooCMatrix, double) norm(2)}.
+     *
+     * @param src Matrix to compute the norm.
+     * @return the 2-norm of this tensor.
+     */
+    public static double norm(CooCMatrix src) {
+        // Sparse implementation is usually only faster for very sparse matrices.
+        return src.sparsity()>=0.95 ? ComplexSparseNorms.matrixNormL2(src) :
+                norm(src.toDense());
+    }
+
+
+    /**
+     * Computes the p-norm of this tensor.
+     *
+     * @param src Matrix to compute the norm.
+     * @param p The p value in the p-norm. <br>
+     *          - If p is inf, then this method computes the maximum/infinite norm.
+     * @return The p-norm of this tensor.
+     * @throws IllegalArgumentException If p is less than 1.
+     */
+    public static double norm(CooCMatrix src, double p) {
+        // Sparse implementation is usually only faster for very sparse matrices.
+        return src.sparsity()>=0.95 ? ComplexSparseNorms.matrixNormLp(src, p) :
+                norm(src.toDense(), p);
+    }
+
+
+    // CSR Matrices
+
+    /**
+     * Computes the L<sub>p, q</sub> norm of this matrix.
+     *
+     * @param src Matrix to compute norm of.
+     * @param p P value in the L<sub>p, q</sub> norm.
+     * @param q Q value in the L<sub>p, q</sub> norm.
+     * @return The L<sub>p, q</sub> norm of this matrix.
+     */
+    public static double norm(CsrMatrix src, double p, double q) {
+        return RealCsrOperations.matrixNormLpq(src, p, q);
+    }
+
+
+    /**
+     * Computes the max norm of a matrix.
+     *
+     * @param src Matrix to compute norm of.
+     * @return The max norm of this matrix.
+     */
+    public static double maxNorm(CsrMatrix src) {
+        return RealDenseOperations.matrixMaxNorm(src.entries);
+    }
+
+
+    /**
+     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(CsrMatrix, double) norm(2)}.
+     *
+     * @param src Matrix to compute the norm of.
+     * @return the 2-norm of this tensor.
+     */
+    public double norm(CsrMatrix src) {
+        return RealDenseOperations.tensorNormL2(src.entries); // Zeros do not contribute to this norm.
+    }
+
+
+    /**
+     * Computes the p-norm of this tensor.
+     *
+     * @param src Matrix to compute norm of.
+     * @param p The p value in the p-norm. <br>
+     *          - If p is inf, then this method computes the maximum/infinite norm.
+     * @return The p-norm of this tensor.
+     * @throws IllegalArgumentException If p is less than 1.
+     */
+    public double norm(CsrMatrix src, double p) {
+        return RealDenseOperations.tensorNormLp(src.entries, p); // Zeros do not contribute to this norm.
+    }
+}

--- a/src/main/java/org/flag4j/linalg/TensorNorms.java
+++ b/src/main/java/org/flag4j/linalg/TensorNorms.java
@@ -1,0 +1,61 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024. Jacob Watters
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.flag4j.linalg;
+
+import org.flag4j.core.dense_base.ComplexDenseTensorBase;
+import org.flag4j.core.dense_base.RealDenseTensorBase;
+import org.flag4j.util.ErrorMessages;
+
+
+/**
+ * Utility class for computing norms of tensors.
+ */
+public class TensorNorms {
+
+    private TensorNorms() {
+        // Hide default constructor for utility class
+        throw new IllegalStateException(ErrorMessages.getUtilityClassErrMsg());
+    }
+
+
+    /**
+     * Computes the infinity norm of a tensor, matrix, or vector. That is, the largest absolute value.
+     * @param src The tensor, matrix, or vector to compute the norm of.
+     * @return The infinity norm of the source matrix.
+     */
+    public static double infNorm(RealDenseTensorBase<?, ?> src) {
+        return src.maxAbs();
+    }
+
+
+    /**
+     * Computes the infinity norm of a tensor, matrix, or vector. That is, the largest value by magnitude.
+     * @param src The tensor, matrix, or vector to compute the norm of.
+     * @return The infinity norm of the source matrix.
+     */
+    public static double infNorm(ComplexDenseTensorBase<?, ?> src) {
+        return src.maxAbs();
+    }
+}

--- a/src/main/java/org/flag4j/linalg/VectorNorms.java
+++ b/src/main/java/org/flag4j/linalg/VectorNorms.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024. Jacob Watters
+ * Copyright (c) 2024. Jacob Watters
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,29 +22,137 @@
  * SOFTWARE.
  */
 
-package org.flag4j.operations.common.real;
-
+package org.flag4j.linalg;
 
 import org.flag4j.complex_numbers.CNumber;
+import org.flag4j.core.dense_base.ComplexDenseTensorBase;
+import org.flag4j.core.dense_base.RealDenseTensorBase;
+import org.flag4j.dense.CVector;
+import org.flag4j.dense.Vector;
 import org.flag4j.operations.common.complex.AggregateComplex;
+import org.flag4j.operations.common.real.AggregateReal;
+import org.flag4j.sparse.CooCVector;
+import org.flag4j.sparse.CooVector;
+import org.flag4j.util.ErrorMessages;
+
 
 /**
- * This class contains low level implementations of vector norms for real valued vectors.
+ * Utility class for computing norms of vectors. To compute the infinite norm see
+ * {@link TensorNorms#infNorm(ComplexDenseTensorBase)} or {@link TensorNorms#infNorm(RealDenseTensorBase)}
  */
 public class VectorNorms {
 
     private VectorNorms() {
-        // Hide default constructor for utility class.
-        throw new IllegalStateException();
+        // Hide default constructor for utility class
+        throw new IllegalStateException(ErrorMessages.getUtilityClassErrMsg());
+    }
+
+    /**
+     * Computes the 2-norm of this vector. This is equivalent to {@link #norm(Vector, double) norm(2)}.
+     *
+     * @param src Vector to compute norm of.
+     * @return the 2-norm of this vector.
+     */
+    public static double norm(Vector src) {
+        return norm(src.entries);
     }
 
 
+    /**
+     * Computes the p-norm of this vector.
+     *
+     * @param src Vector to compute norm of.
+     * @param p The p value in the p-norm. <br>
+     *          - If p is inf, then this method computes the maximum/infinite norm.
+     * @return The p-norm of this vector.
+     * @throws IllegalArgumentException If p is less than 1.
+     */
+    public static double norm(Vector src, double p) {
+        return norm(src.entries, p);
+    }
+
+
+    /**
+     * Computes the 2-norm of this vector. This is equivalent to {@link #norm(Vector, double) norm(2)}.
+     *
+     * @param src Vector to compute norm of.
+     * @return the 2-norm of this vector.
+     */
+    public static double norm(CooVector src) {
+        return norm(src.entries);
+    }
+
+
+    /**
+     * Computes the p-norm of this vector.
+     *
+     * @param src Vector to compute norm of.
+     * @param p The p value in the p-norm. <br>
+     *          - If p is inf, then this method computes the maximum/infinite norm.
+     * @return The p-norm of this vector.
+     * @throws IllegalArgumentException If p is less than 1.
+     */
+    public static double norm(CooVector src, double p) {
+        return norm(src.entries, p);
+    }
+
+
+    /**
+     * Computes the 2-norm of this vector. This is equivalent to {@link #norm(CVector, double) norm(2)}.
+     *
+     * @return the 2-norm of this vector.
+     */
+    public static double norm(CVector src) {
+        return VectorNorms.norm(src.entries);
+    }
+
+
+    /**
+     * Computes the p-norm of this vector. Warning, if p is large in absolute value, overflow issues may occur.
+     *
+     * @param p The p value in the p-norm. <br>
+     *          - If p is {@link Double#POSITIVE_INFINITY}, then this method computes the maximum/infinite norm. <br>
+     *          - If p is {@link Double#NEGATIVE_INFINITY}, then this method computes the minimum norm.
+     * @return The p-norm of this vector.
+     */
+    public static double norm(CVector src, double p) {
+        return VectorNorms.norm(src.entries, p);
+    }
+
+
+    /**
+     * Computes the 2-norm of this vector. This is equivalent to {@link #norm(CooCVector, double) norm(2)}.
+     *
+     * @param src Vector to compute norm of.
+     * @return the 2-norm of this vector.
+     */
+    public static double norm(CooCVector src) {
+        return VectorNorms.norm(src.entries);
+    }
+
+
+    /**
+     * Computes the p-norm of this vector.
+     *
+     * @param src Vector to compute norm of.
+     * @param p The p value in the p-norm. <br>
+     *          - If p is inf, then this method computes the maximum/infinite norm.
+     * @return The p-norm of this vector.
+     * @throws IllegalArgumentException If p is less than 1.
+     */
+    public static double norm(CooCVector src, double p) {
+        return VectorNorms.norm(src.entries, p);
+    }
+
+
+
+    // ---------------------------------------------- Low-level Implementations ----------------------------------------------
     /**
      * Computes the 2-norm of a vector.
      * @param src Entries of the vector (or non-zero entries if vector is sparse).
      * @return The 2-norm of the vector.
      */
-    public static double norm(double... src) {
+    private static double norm(double... src) {
         double norm = 0;
         double maxAbs = AggregateReal.maxAbs(src);
         if(maxAbs == 0) return 0; // Early return for zero norm.
@@ -64,7 +172,7 @@ public class VectorNorms {
      * @param src Entries of the vector (or non-zero entries if vector is sparse).
      * @return The 2-norm of the vector.
      */
-    public static double norm(CNumber... src) {
+    private static double norm(CNumber... src) {
         double norm = 0;
         double scaledMag;
         double maxAbs = AggregateComplex.maxAbs(src);
@@ -90,7 +198,7 @@ public class VectorNorms {
      *          Warning, if {@code p} is large in absolute value, overflow errors may occur.
      * @return The {@code p}-norm of the vector.
      */
-    public static double norm(double[] src, double p) {
+    private static double norm(double[] src, double p) {
         if(Double.isInfinite(p)) {
             if(p > 0) {
                 return AggregateReal.maxAbs(src); // Maximum / infinite norm.
@@ -118,7 +226,7 @@ public class VectorNorms {
      *          Warning, if {@code p} is large in absolute value, overflow errors may occur.
      * @return The {@code p}-norm of the vector.
      */
-    public static double norm(CNumber[] src, double p) {
+    private static double norm(CNumber[] src, double p) {
         if(Double.isInfinite(p)) {
             if(p > 0) {
                 return AggregateComplex.maxAbs(src); // Maximum / infinite norm.

--- a/src/main/java/org/flag4j/sparse/CooCMatrix.java
+++ b/src/main/java/org/flag4j/sparse/CooCMatrix.java
@@ -34,10 +34,8 @@ import org.flag4j.dense.CVector;
 import org.flag4j.dense.Matrix;
 import org.flag4j.dense.Vector;
 import org.flag4j.io.PrintOptions;
-import org.flag4j.linalg.decompositions.svd.SVD;
 import org.flag4j.operations.TransposeDispatcher;
 import org.flag4j.operations.common.complex.ComplexOperations;
-import org.flag4j.operations.dense.complex.ComplexDenseOperations;
 import org.flag4j.operations.dense_sparse.coo.complex.ComplexDenseSparseEquals;
 import org.flag4j.operations.dense_sparse.coo.complex.ComplexDenseSparseMatrixMultiplication;
 import org.flag4j.operations.dense_sparse.coo.complex.ComplexDenseSparseMatrixOperations;
@@ -2270,19 +2268,6 @@ public class CooCMatrix
 
 
     /**
-     * Computes the condition number of this matrix using the {@link SVD SVD}.
-     * Specifically, the condition number is computed as the maximum singular value divided by the minimum singular
-     * value of this matrix.
-     *
-     * @return The condition number of this matrix (Assuming Frobenius norm).
-     */
-    @Override
-    public double cond() {
-        return toDense().cond();
-    }
-
-
-    /**
      * Extracts the diagonal elements of this matrix and returns them as a vector.
      *
      * @return A vector containing the diagonal entries of this matrix.
@@ -2568,26 +2553,6 @@ public class CooCMatrix
     @Override
     public boolean isI() {
         return ComplexSparseMatrixProperties.isIdentity(this);
-    }
-
-
-    /**
-     * Checks if matrices are inverses of each other.
-     *
-     * @param B Second matrix.
-     * @return True if matrix B is an inverse of this matrix. Otherwise, returns false. Otherwise, returns false.
-     */
-    @Override
-    public boolean isInv(CooCMatrix B) {
-        boolean result;
-
-        if(!this.isSquare() || !B.isSquare() || !shape.equals(B.shape)) {
-            result = false;
-        } else {
-            result = this.mult(B).round().isI();
-        }
-
-        return result;
     }
 
 
@@ -3152,32 +3117,6 @@ public class CooCMatrix
 
 
     /**
-     * Computes the L<sub>p, q</sub> norm of this matrix.
-     *
-     * @param p P value in the L<sub>p, q</sub> norm.
-     * @param q Q value in the L<sub>p, q</sub> norm.
-     * @return The L<sub>p, q</sub> norm of this matrix.
-     */
-    @Override
-    public double norm(double p, double q) {
-        // Sparse implementation is usually only faster for very sparse matrices.
-        return sparsity()>=0.95 ? ComplexSparseNorms.matrixNormLpq(this, p, q) :
-                toDense().norm(p, q);
-    }
-
-
-    /**
-     * Computes the max norm of a matrix.
-     *
-     * @return The max norm of this matrix.
-     */
-    @Override
-    public double maxNorm() {
-        return ComplexDenseOperations.matrixMaxNorm(entries);
-    }
-
-
-    /**
      * Computes the rank of this matrix (i.e. the dimension of the column space of this matrix).
      * Note that here, rank is <b>NOT</b> the same as a tensor rank.
      *
@@ -3200,35 +3139,6 @@ public class CooCMatrix
     public CooCMatrix set(double value, int... indices) {
         ParameterChecks.assertEquals(2, indices.length);
         return set(value, indices[0], indices[1]);
-    }
-
-
-    /**
-     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(double) norm(2)}.
-     *
-     * @return the 2-norm of this tensor.
-     */
-    @Override
-    public double norm() {
-        // Sparse implementation is usually only faster for very sparse matrices.
-        return sparsity()>=0.95 ? ComplexSparseNorms.matrixNormL2(this) :
-                toDense().norm();
-    }
-
-
-    /**
-     * Computes the p-norm of this tensor.
-     *
-     * @param p The p value in the p-norm. <br>
-     *          - If p is inf, then this method computes the maximum/infinite norm.
-     * @return The p-norm of this tensor.
-     * @throws IllegalArgumentException If p is less than 1.
-     */
-    @Override
-    public double norm(double p) {
-        // Sparse implementation is usually only faster for very sparse matrices.
-        return sparsity()>=0.95 ? ComplexSparseNorms.matrixNormLp(this, p) :
-                toDense().norm(p);
     }
 
 

--- a/src/main/java/org/flag4j/sparse/CooCVector.java
+++ b/src/main/java/org/flag4j/sparse/CooCVector.java
@@ -34,7 +34,6 @@ import org.flag4j.dense.Vector;
 import org.flag4j.io.PrintOptions;
 import org.flag4j.operations.common.complex.ComplexOperations;
 import org.flag4j.operations.common.complex.ComplexProperties;
-import org.flag4j.operations.common.real.VectorNorms;
 import org.flag4j.operations.dense.complex.AggregateDenseComplex;
 import org.flag4j.operations.dense.complex.ComplexDenseOperations;
 import org.flag4j.operations.dense.real.RealDenseTranspose;
@@ -1236,19 +1235,6 @@ public class CooCVector
 
 
     /**
-     * Computes a unit vector in the same direction as this vector.
-     *
-     * @return A unit vector with the same direction as this vector. If this vector is zeros, then an equivalently sized
-     * zero vector will be returned.
-     */
-    @Override
-    public CooCVector normalize() {
-        double norm = this.norm();
-        return norm==0 ? new CooCVector(size) : this.div(norm);
-    }
-
-
-    /**
      * Computes the inner product between two vectors.
      *
      * @param b Second vector in the inner product.
@@ -1459,31 +1445,6 @@ public class CooCVector
     public int[] argMax() {
         int idx = AggregateDenseComplex.argMax(entries);
         return new int[]{indices[idx]};
-    }
-
-
-    /**
-     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(double) norm(2)}.
-     *
-     * @return the 2-norm of this tensor.
-     */
-    @Override
-    public double norm() {
-        return VectorNorms.norm(entries);
-    }
-
-
-    /**
-     * Computes the p-norm of this tensor.
-     *
-     * @param p The p value in the p-norm. <br>
-     *          - If p is inf, then this method computes the maximum/infinite norm.
-     * @return The p-norm of this tensor.
-     * @throws IllegalArgumentException If p is less than 1.
-     */
-    @Override
-    public double norm(double p) {
-        return VectorNorms.norm(entries, p);
     }
 
 

--- a/src/main/java/org/flag4j/sparse/CooMatrix.java
+++ b/src/main/java/org/flag4j/sparse/CooMatrix.java
@@ -34,10 +34,8 @@ import org.flag4j.dense.CVector;
 import org.flag4j.dense.Matrix;
 import org.flag4j.dense.Vector;
 import org.flag4j.io.PrintOptions;
-import org.flag4j.linalg.decompositions.svd.SVD;
 import org.flag4j.operations.TransposeDispatcher;
 import org.flag4j.operations.common.complex.ComplexOperations;
-import org.flag4j.operations.dense.real.RealDenseOperations;
 import org.flag4j.operations.dense.real.RealDenseTranspose;
 import org.flag4j.operations.dense_sparse.coo.real.RealDenseSparseEquals;
 import org.flag4j.operations.dense_sparse.coo.real.RealDenseSparseMatrixMultiplication;
@@ -600,26 +598,6 @@ public class CooMatrix
     @Override
     public boolean isI() {
         return RealSparseMatrixProperties.isIdentity(this);
-    }
-
-
-    /**
-     * Checks if matrices are inverses of each other.
-     *
-     * @param B Second matrix.
-     * @return True if matrix B is an inverse of this matrix. Otherwise, returns false. Otherwise, returns false.
-     */
-    @Override
-    public boolean isInv(CooMatrix B) {
-        boolean result;
-
-        if(!this.isSquare() || !B.isSquare() || !shape.equals(B.shape)) {
-            result = false;
-        } else {
-            result = this.mult(B).round().isI();
-        }
-
-        return result;
     }
 
 
@@ -2528,23 +2506,6 @@ public class CooMatrix
 
         return trace;
     }
-
-
-    /**
-     * Computes the condition number of this matrix using {@link SVD SVD}.
-     * Specifically, the condition number is computed as the maximum singular value divided by the minimum singular
-     * value of this matrix.
-     *
-     * <p>
-     *     WARNING: This method will convert the sparse matrix to a dense matrix to perform the computation.
-     * </p>
-     *
-     * @return The condition number of this matrix (Assuming Frobenius norm).
-     */
-    @Override
-    public double cond() {
-        return toDense().cond();
-    }
     
 
     /**
@@ -2827,32 +2788,6 @@ public class CooMatrix
 
 
     /**
-     * Computes the L<sub>p, q</sub> norm of this matrix.
-     *
-     * @param p P value in the L<sub>p, q</sub> norm.
-     * @param q Q value in the L<sub>p, q</sub> norm.
-     * @return The L<sub>p, q</sub> norm of this matrix.
-     */
-    @Override
-    public double norm(double p, double q) {
-        // Sparse implementation is usually only faster for very sparse matrices.
-        return sparsity()>=0.95 ? RealSparseNorms.matrixNormLpq(this, p, q) :
-                toDense().norm(p, q);
-    }
-
-
-    /**
-     * Computes the max norm of a matrix.
-     *
-     * @return The max norm of this matrix.
-     */
-    @Override
-    public double maxNorm() {
-        return RealDenseOperations.matrixMaxNorm(entries);
-    }
-
-
-    /**
      * Computes the rank of this matrix (i.e. the dimension of the column space of this matrix).
      * Note that here, rank is <b>NOT</b> the same as a tensor rank.
      *
@@ -2988,35 +2923,6 @@ public class CooMatrix
         }
 
         return new CooMatrix(new Shape(dims), entries.clone(), rowIndices, colIndices);
-    }
-
-
-    /**
-     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(double) norm(2)}.
-     *
-     * @return the 2-norm of this tensor.
-     */
-    @Override
-    public double norm() {
-        // Sparse implementation is usually only faster for very sparse matrices.
-        return sparsity()>=0.95 ? RealSparseNorms.matrixNormL2(this) :
-                toDense().norm();
-    }
-
-
-    /**
-     * Computes the p-norm of this tensor.
-     *
-     * @param p The p value in the p-norm. <br>
-     *          - If p is inf, then this method computes the maximum/infinite norm.
-     * @return The p-norm of this tensor.
-     * @throws IllegalArgumentException If p is less than 1.
-     */
-    @Override
-    public double norm(double p) {
-        // Sparse implementation is usually only faster for very sparse matrices.
-        return sparsity()>=0.95 ? RealSparseNorms.matrixNormLp(this, p) :
-                toDense().norm(p);
     }
 
 

--- a/src/main/java/org/flag4j/sparse/CooVector.java
+++ b/src/main/java/org/flag4j/sparse/CooVector.java
@@ -33,9 +33,9 @@ import org.flag4j.dense.CVector;
 import org.flag4j.dense.Matrix;
 import org.flag4j.dense.Vector;
 import org.flag4j.io.PrintOptions;
+import org.flag4j.linalg.VectorNorms;
 import org.flag4j.operations.common.complex.ComplexOperations;
 import org.flag4j.operations.common.real.RealOperations;
-import org.flag4j.operations.common.real.VectorNorms;
 import org.flag4j.operations.dense.real.RealDenseTranspose;
 import org.flag4j.operations.dense_sparse.coo.real.RealDenseSparseEquals;
 import org.flag4j.operations.dense_sparse.coo.real.RealDenseSparseVectorOperations;
@@ -913,7 +913,7 @@ public class CooVector
      */
     @Override
     public CooVector normalize() {
-        double norm = this.norm();
+        double norm = VectorNorms.norm(this);
         return norm==0 ? new CooVector(size) : this.div(norm);
     }
 
@@ -1132,42 +1132,6 @@ public class CooVector
                 this.entries.clone(),
                 RealDenseTranspose.blockedIntMatrix(new int[][]{this.indices.clone()})
         );
-    }
-
-
-    /**
-     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(double) norm(2)}.
-     *
-     * @return the 2-norm of this tensor.
-     */
-    @Override
-    public double norm() {
-        return VectorNorms.norm(entries);
-    }
-
-
-    /**
-     * Computes the p-norm of this tensor.
-     *
-     * @param p The p value in the p-norm. <br>
-     *          - If p is inf, then this method computes the maximum/infinite norm.
-     * @return The p-norm of this tensor.
-     * @throws IllegalArgumentException If p is less than 1.
-     */
-    @Override
-    public double norm(double p) {
-        return VectorNorms.norm(entries, p);
-    }
-
-
-    /**
-     * Computes the maximum/infinite norm of this tensor.
-     *
-     * @return The maximum/infinite norm of this tensor.
-     */
-    @Override
-    public double infNorm() {
-        return maxAbs();
     }
 
 

--- a/src/main/java/org/flag4j/sparse/CsrMatrix.java
+++ b/src/main/java/org/flag4j/sparse/CsrMatrix.java
@@ -35,9 +35,7 @@ import org.flag4j.dense.CVector;
 import org.flag4j.dense.Matrix;
 import org.flag4j.dense.Vector;
 import org.flag4j.io.PrintOptions;
-import org.flag4j.linalg.decompositions.svd.SVD;
 import org.flag4j.operations.common.complex.ComplexOperations;
-import org.flag4j.operations.dense.real.RealDenseOperations;
 import org.flag4j.operations.dense_sparse.csr.real.RealCsrDenseMatrixMultiplication;
 import org.flag4j.operations.dense_sparse.csr.real.RealCsrDenseOperations;
 import org.flag4j.operations.dense_sparse.csr.real_complex.RealComplexCsrDenseMatrixMultiplication;
@@ -1492,19 +1490,6 @@ public class CsrMatrix
 
 
     /**
-     * Computes the condition number of this matrix using {@link SVD SVD}.
-     * Specifically, the condition number is computed as the maximum singular value divided by the minimum singular
-     * value of this matrix.
-     *
-     * @return The condition number of this matrix (Assuming Frobenius norm).
-     */
-    @Override
-    public double cond() {
-        return toDense().cond();
-    }
-
-
-    /**
      * Extracts the diagonal elements of this matrix and returns them as a vector.
      *
      * @return A vector containing the diagonal entries of this matrix.
@@ -1634,26 +1619,6 @@ public class CsrMatrix
      */
     public boolean isI() {
         return RealCsrMatrixProperties.isIdentity(this);
-    }
-
-    
-    /**
-     * Checks if matrices are inverses of each other.
-     *
-     * @param B Second matrix.
-     * @return True if matrix B is an inverse of this matrix. Otherwise, returns false. Otherwise, returns false.
-     */
-    @Override
-    public boolean isInv(CsrMatrix B) {
-        boolean result;
-
-        if(!this.isSquare() || !B.isSquare() || !shape.equals(B.shape)) {
-            result = false;
-        } else {
-            result = this.mult(B).isCloseToI();
-        }
-
-        return result;
     }
 
 
@@ -2267,30 +2232,6 @@ public class CsrMatrix
 
 
     /**
-     * Computes the L<sub>p, q</sub> norm of this matrix.
-     *
-     * @param p P value in the L<sub>p, q</sub> norm.
-     * @param q Q value in the L<sub>p, q</sub> norm.
-     * @return The L<sub>p, q</sub> norm of this matrix.
-     */
-    @Override
-    public double norm(double p, double q) {
-        return RealCsrOperations.matrixNormLpq(this, p, q);
-    }
-
-
-    /**
-     * Computes the max norm of a matrix.
-     *
-     * @return The max norm of this matrix.
-     */
-    @Override
-    public double maxNorm() {
-        return RealDenseOperations.matrixMaxNorm(entries);
-    }
-
-
-    /**
      * Computes the rank of this matrix (i.e. the dimension of the column space of this matrix).
      * Note that here, rank is <b>NOT</b> the same as a tensor rank.
      *
@@ -2583,31 +2524,6 @@ public class CsrMatrix
     @Override
     public CsrMatrix elemDiv(Matrix B) {
         return RealCsrDenseOperations.applyBinOppToSparse(B, this, (Double x, Double y)->y/x);
-    }
-
-
-    /**
-     * Computes the 2-norm of this tensor. This is equivalent to {@link #norm(double) norm(2)}.
-     *
-     * @return the 2-norm of this tensor.
-     */
-    @Override
-    public double norm() {
-        return RealDenseOperations.tensorNormL2(entries); // Zeros do not contribute to this norm.
-    }
-
-
-    /**
-     * Computes the p-norm of this tensor.
-     *
-     * @param p The p value in the p-norm. <br>
-     *          - If p is inf, then this method computes the maximum/infinite norm.
-     * @return The p-norm of this tensor.
-     * @throws IllegalArgumentException If p is less than 1.
-     */
-    @Override
-    public double norm(double p) {
-        return RealDenseOperations.tensorNormLp(entries, p); // Zeros do not contribute to this norm.
     }
 
 

--- a/src/test/java/org/flag4j/operations/common/real/MatrixNormTests.java
+++ b/src/test/java/org/flag4j/operations/common/real/MatrixNormTests.java
@@ -1,6 +1,7 @@
 package org.flag4j.operations.common.real;
 
 import org.flag4j.dense.Matrix;
+import org.flag4j.linalg.MatrixNorms;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,7 +20,7 @@ class MatrixNormTests {
         A = new Matrix(aEntries);
         expNorm = 932.45;
 
-        assertEquals(expNorm, A.maxNorm());
+        assertEquals(expNorm, MatrixNorms.maxNorm(A));
     }
 
 
@@ -30,7 +31,7 @@ class MatrixNormTests {
         A = new Matrix(aEntries);
         expNorm = 1609.2234200000003;
 
-        assertEquals(expNorm, A.infNorm());
+        assertEquals(expNorm, MatrixNorms.infNorm(A));
     }
 
 
@@ -41,66 +42,66 @@ class MatrixNormTests {
         A = new Matrix(aEntries);
         expNorm = 1094.9348777384303;
 
-        assertEquals(expNorm, A.norm());
+        assertEquals(expNorm, MatrixNorms.norm(A));
 
         // ---------------- Sub-case 2  ----------------
         aEntries = new double[][]{{1.1234, 99.234, 0.000123}, {-932.45, 551.35, -0.92342}, {123.445, 0.00013, 0}};
         A = new Matrix(aEntries);
         expNorm = 1094.7776004801563;
 
-        assertEquals(expNorm, A.norm());
+        assertEquals(expNorm, MatrixNorms.norm(A));
 
         // ---------------- Sub-case 3  ----------------
         aEntries = new double[][]{{1.1234, 99.234, 0.000123}, {-932.45, 551.35, -0.92342}, {123.445, 0.00013, 0}};
         A = new Matrix(aEntries);
         expNorm = 1094.7776004801563;
 
-        assertEquals(expNorm, A.norm(2));
+        assertEquals(expNorm, MatrixNorms.norm(A,2));
 
         // ---------------- Sub-case 4  ----------------
         aEntries = new double[][]{{1.1234, 99.234, 0.000123}, {-932.45, 551.35, -0.92342}, {123.445, 0.00013, 0}};
         A = new Matrix(aEntries);
         expNorm = 1708.5260729999998;
 
-        assertEquals(expNorm, A.norm(1));
+        assertEquals(expNorm, MatrixNorms.norm(A,1));
 
         // ---------------- Sub-case 5  ----------------
         aEntries = new double[][]{{1.1234, 99.234, 0.000123}, {-932.45, 551.35, -0.92342}, {123.445, 0.00013, 0}};
         A = new Matrix(aEntries);
         expNorm = 1094.7776004801563;
 
-        assertEquals(expNorm, A.norm(2, 2));
+        assertEquals(expNorm, MatrixNorms.norm(A,2, 2));
 
         // ---------------- Sub-case 6  ----------------
         aEntries = new double[][]{{1.1234, 99.234, 0.000123}, {-932.45, 551.35, -0.92342}, {123.445, 0.00013, 0}};
         A = new Matrix(aEntries);
         expNorm = 1002.6438019443739;
 
-        assertEquals(expNorm, A.norm(2, 3));
+        assertEquals(expNorm, MatrixNorms.norm(A,2, 3));
 
         // ---------------- Sub-case 7  ----------------
         aEntries = new double[][]{{1.1234, 99.234, 0.000123}, {-932.45, 551.35, -0.92342}, {123.445, 0.00013, 0}};
         A = new Matrix(aEntries);
         expNorm = 1501.7189796784505;
 
-        assertEquals(expNorm, A.norm(2, 1));
+        assertEquals(expNorm, MatrixNorms.norm(A,2, 1));
 
         // ---------------- Sub-case 8  ----------------
         aEntries = new double[][]{{1.1234, 99.234, 0.000123}, {-932.45, 551.35, -0.92342}, {123.445, 0.00013, 0}};
         A = new Matrix(aEntries);
 
-        assertThrows(IllegalArgumentException.class, ()->A.norm(0));
+        assertThrows(IllegalArgumentException.class, ()->MatrixNorms.norm(A,0));
 
         // ---------------- Sub-case 10  ----------------
         aEntries = new double[][]{{1.1234, 99.234, 0.000123}, {-932.45, 551.35, -0.92342}, {123.445, 0.00013, 0}};
         A = new Matrix(aEntries);
 
-        assertThrows(IllegalArgumentException.class, ()->A.norm(0, 1));
+        assertThrows(IllegalArgumentException.class, ()->MatrixNorms.norm(A, 0, 1));
 
         // ---------------- Sub-case 11  ----------------
         aEntries = new double[][]{{1.1234, 99.234, 0.000123}, {-932.45, 551.35, -0.92342}, {123.445, 0.00013, 0}};
         A = new Matrix(aEntries);
 
-        assertThrows(IllegalArgumentException.class, ()->A.norm(1, -12));
+        assertThrows(IllegalArgumentException.class, ()->MatrixNorms.norm(A,1, -12));
     }
 }


### PR DESCRIPTION
…sor, matrix, or vector the utility classes in org.flag4j.linalg